### PR TITLE
fix: disable SSL certificate verification

### DIFF
--- a/Complete_code.ino
+++ b/Complete_code.ino
@@ -222,6 +222,8 @@ void loop() {
 void sendDataToServer(float temperature, String temperatureStatus, float humidity, String humidityStatus, int gasLevel, String gasLevelStatus) {
   if (WiFiMulti.run() == WL_CONNECTED) {
     WiFiClient client;
+    client.setInsecure(); // disable SSL certificate
+    
     HTTPClient http;
     String url = "https://air-quality-monitor-two.vercel.app/update";
 


### PR DESCRIPTION
status code 308 indicates a permanent redirect, which might be causing the issue with data not being received by the server. To handle this, SSL certificate verification has been disabled to ensure the redirect uses the correct URL

resolves send data to server